### PR TITLE
Add min tilt version plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ This is the official Tilt Extensions Repository. All extensions here have been v
 - [`docker_build_sub`](/docker_build_sub): Specify extra Dockerfile directives in your Tiltfile beyond [`docker_build`](https://docs.tilt.dev/api.html#api.docker_build).
 - [`hello_world`](/hello_world): Print "Hello world!". Used in [Extensions](https://docs.tilt.dev/extensions.html).
 - [`jest_test_runner`](/jest_test_runner): Jest JavaScript test runner. Example from [Contribute an Extension](https://docs.tilt.dev/contribute_extension.html).
+- [`min_tilt_version`](/min_tilt_version): Require a minimum Tilt version to run this Tiltfile.
 - [`print_tiltfile_dir`](/print_tiltfile_dir): Print all files in the Tiltfile directory. If recursive is set to True, also prints files in all recursive subdirectories.
 - [`procfile`](/procfile): Create Tilt resources from a foreman Procfile.
-- [`min_tilt_version`](/min_tilt_version): Allows you to require a minimum codified tilt version to run this Tiltfile 
+
 
 ## Contribute an Extension
 See [Contribute an Extension](https://docs.tilt.dev/contribute_extension.html).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is the official Tilt Extensions Repository. All extensions here have been v
 - [`jest_test_runner`](/jest_test_runner): Jest JavaScript test runner. Example from [Contribute an Extension](https://docs.tilt.dev/contribute_extension.html).
 - [`print_tiltfile_dir`](/print_tiltfile_dir): Print all files in the Tiltfile directory. If recursive is set to True, also prints files in all recursive subdirectories.
 - [`procfile`](/procfile): Create Tilt resources from a foreman Procfile.
+- [`min_tilt_version`](/min_tilt_version): Allows you to require a minimum codified tilt version to run this Tiltfile 
 
 ## Contribute an Extension
 See [Contribute an Extension](https://docs.tilt.dev/contribute_extension.html).

--- a/min_tilt_version/README.md
+++ b/min_tilt_version/README.md
@@ -1,12 +1,12 @@
 # Min Tilt Version
 
-Allows you to specify a minimum tilt version to run required this TiltFile
+Specify a minimum Tilt version to run this TiltFile
 
-Requiring a minimum will cause tilt to stop execution using `fail` api
+If the minimum version is not met, Tilt will stop executing using the `fail` api
 
 ## Usage
 
-Its advisable to include this as close to the top of the `Tiltfile` as possible.
+It's advisable to include this as close to the top of the Tiltfile as possible.
 
 Include patch version
 

--- a/min_tilt_version/README.md
+++ b/min_tilt_version/README.md
@@ -1,0 +1,27 @@
+# Min Tilt Version
+
+Allows you to specify a minimum tilt version to run required this TiltFile
+
+Requiring a minimum will cause tilt to stop execution using `fail` api
+
+## Usage
+
+Its advisable to include this as close to the top of the `Tiltfile` as possible.
+
+Include patch version
+
+```py
+load('ext://min_tilt_version', 'min_tilt_version')
+min_tilt_version('0.13.0')
+```
+
+Only care about minor
+
+```py
+load('ext://min_tilt_version', 'min_tilt_version')
+min_tilt_version('0.13')
+```
+
+## Requirements
+
+* `tilt` binary must be in your path

--- a/min_tilt_version/Tiltfile
+++ b/min_tilt_version/Tiltfile
@@ -1,0 +1,27 @@
+def min_tilt_version(min_version):
+  # this assumes that the tit version command always returns
+  # v0.13.0, built 2020-04-01
+  # Also supports dev versions
+  # v0.13.0-dev, built 2020-04-03
+
+  ver_string = str(local('tilt version', quiet=True))
+  # Clean out the version file so its in the format 0.13.0
+  versions = ver_string.split(', ')
+  # pull first string and remove the `v` and `-dev`
+  version = versions[0].replace('v', '').replace('-dev', '')
+
+  # Python allows you to compare two tuples
+  # (0, 12, 0) < (0, 12, 1)
+  tup_version = _version_tuple(version)
+  tup_min_version = _version_tuple(min_version)
+
+  if tup_version < tup_min_version:
+    print('+--+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+')
+    print('|                      Tilt Version is out of date!                          |')
+    print('|       Please upgrade https://docs.tilt.dev/upgrade.html                    |')
+    print('+--+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+')
+    fail('Tilt version is out of date minimum required version is [%s]' % min_version)
+
+# Private methods
+def _version_tuple(v):
+  return [int(str_num) for str_num in v.split(".")]


### PR DESCRIPTION
Adds `min_tilt_version` function to allow you to codify your minimum requirements. 

This solves the time old issue when working on a team and adding new features to tilt and having tilt output some cryptic error message saying some feature/function doesn't work and teammates not knowing to upgrade tilt. 

References https://github.com/windmilleng/tilt/issues/3125  but I believe this is a much better solution to that same problem

References https://github.com/windmilleng/tilt/issues/3159 (but I see there is a native implementation already in PR https://github.com/windmilleng/tilt/pull/3172/files )

I am submitting this since I already built it, but obviously native version is nicer.

p.s I think requiring a readme for each plugin is a nice touch. 
