### PR TITLE
docs for restart_process extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ All extensions have been vetted and approved by the Tilt team.
 - [`pack`](/pack): Build container images using [pack](https://buildpacks.io/docs/install-pack/) and [buildpacks](https://buildpacks.io/).
 - [`print_tiltfile_dir`](/print_tiltfile_dir): Print all files in the Tiltfile directory. If recursive is set to True, also prints files in all recursive subdirectories.
 - [`procfile`](/procfile): Create Tilt resources from a foreman Procfile.
+- [`restart_process`](/restart_process): Wrap a `docker_build` to restart the given entrypoint after a Live Update (replaces `restart_container()`)
 
 ## Contribute an Extension
 See [Contribute an Extension](https://docs.tilt.dev/contribute_extension.html).

--- a/restart_process/README.md
+++ b/restart_process/README.md
@@ -3,8 +3,57 @@
 🚨 Still Under Development! 🚨
 This extension is still actively in development, use at your own risk.
 
-This extension wraps a `docker_build` call such that at the end of a live_update, the container's process will rerun itself.
+This extension wraps a `docker_build` call such that at the end of a `live_update`, the container's process will rerun itself. (Use it in place of the `restart_container()` Live Update step, which doesn't work for all users and will soon be deprecated.)
 
-TODO: documentation
-TODO: release instructions
-TODO: custom_build support
+## When to Use
+Use this extension when you have an image (via `docker_build`) and you want to re-execute its entrypoint/command as part of a `live_update`.
+
+E.g. if your app is a static binary, you'll probably need to re-execute the binary for any changes you made to take effect.
+
+(If your app has hot reloading capabilities---i.e. it can detect and incorporate changes to its source code without needing to restart---you probably don't need this extension.)
+
+## How to Use
+
+Import this extension by putting the following at the top of your Tiltfile:
+```python
+load('ext://restart_process', 'docker_build_with_restart')
+```
+
+For the image that needs the process restart, replace your existing `docker_build` call:
+```python
+docker_build(
+    'foo-image',
+    './foo',
+    arg1=val1,
+    arg2=val2,
+    live_update=[x, y, z...]
+)
+```
+with a `docker_build_with_restart` call:
+```python
+docker_build_with_restart(
+    'foo-image',
+    './foo',
+    '/go/bin/foo',
+    arg1=val1,
+    arg2=val2,
+    live_update=[x, y, z...]
+)
+```
+The call above looks just like the initial `docker_build` call except for one added parameter, `entrypoint` (in this example, `/go/bin/foo`). This is the command that you want to run on container start and _re-run_ on Live Update.
+
+## What's Happening Under the Hood
+
+TODO(maia) 👀
+
+## Unsupported Cases
+This extension does NOT support process restarts for:
+- Docker images without shell support (e.g. `scratch`)
+- Images run in Docker Compose resources
+- `custom_build`
+- ???
+
+Run into a bug? Need a use case that we don't yet support? Let us know---[open an issue](https://github.com/windmilleng/tilt-extensions/issues) or [contact us](https://tilt.dev/contact).
+
+## For Maintainers: Releasing
+TODO(maia) 👀

--- a/restart_process/README.md
+++ b/restart_process/README.md
@@ -1,6 +1,7 @@
 # Restart Process (Alpha)
 
-🚨 Still Under Development! 🚨
+### 🚨 Still Under Development! 🚨
+
 This extension is still actively in development, use at your own risk.
 
 This extension wraps a `docker_build` call such that at the end of a `live_update`, the container's process will rerun itself. (Use it in place of the `restart_container()` Live Update step, which doesn't work for all users and will soon be deprecated.)
@@ -10,7 +11,7 @@ Use this extension when you have an image (via `docker_build`) and you want to r
 
 E.g. if your app is a static binary, you'll probably need to re-execute the binary for any changes you made to take effect.
 
-(If your app has hot reloading capabilities---i.e. it can detect and incorporate changes to its source code without needing to restart---you probably don't need this extension.)
+(If your app has hot reloading capabilities--i.e. it can detect and incorporate changes to its source code without needing to restart--you probably don't need this extension.)
 
 ## How to Use
 
@@ -90,7 +91,7 @@ This extension does NOT support process restarts for:
 - `custom_build`
 - ???
 
-Run into a bug? Need a use case that we don't yet support? Let us know---[open an issue](https://github.com/windmilleng/tilt-extensions/issues) or [contact us](https://tilt.dev/contact).
+Run into a bug? Need a use case that we don't yet support? Let us know--[open an issue](https://github.com/windmilleng/tilt-extensions/issues) or [contact us](https://tilt.dev/contact).
 
 ## For Maintainers: Releasing
 TODO(maia) 👀

--- a/restart_process/README.md
+++ b/restart_process/README.md
@@ -91,7 +91,7 @@ run('date > /.restart-proc')
 Because `tilt-restart-wrapper` will re-execute the entrypoint whenever `/.restart-proc'` changes, the above `run` step will cause the entrypoint to re-run.
 
 #### Provide `tilt-restart-wrapper`
-For this all to work, the `entr` binary must be available on the Docker image. The easiest solution would be to call e.g. `apt-get install entr` in the Dockerfile, but different base images will have different package mangers; rather than grapple with that, we've made a statically linked binary available on Docker image: [`tiltdev/entr`](https://hub.docker.com/repository/docker/tiltdev/entr).
+For this all to work, the `entr` binary must be available on the Docker image. The easiest solution would be to call e.g. `apt-get install entr` in the Dockerfile, but different base images will have different package managers; rather than grapple with that, we've made a statically linked binary available on Docker image: [`tiltdev/entr`](https://hub.docker.com/repository/docker/tiltdev/entr).
 
 To build `image-foo`, this extension will:
 - build your image as normal (via `docker_build`, with all of your specified args/kwargs) but with the name `image-foo-base`

--- a/restart_process/README.md
+++ b/restart_process/README.md
@@ -1,8 +1,4 @@
-# Restart Process (Alpha)
-
-### 🚨 Still Under Development! 🚨
-
-This extension is still actively in development, use at your own risk.
+# Restart Process
 
 This extension wraps a `docker_build` call such that at the end of a `live_update`, the container's process will rerun itself. (Use it in place of the `restart_container()` Live Update step, which doesn't work for all users and will soon be deprecated.)
 

--- a/restart_process/README.md
+++ b/restart_process/README.md
@@ -70,7 +70,7 @@ This extension does NOT support process restarts for:
 Run into a bug? Need a use case that we don't yet support? Let us know--[open an issue](https://github.com/windmilleng/tilt-extensions/issues) or [contact us](https://tilt.dev/contact).
 
 ## What's Happening Under the Hood
-*If you're a casual user/just want to get your app running, you can stop reading now. However, if you want to dig deep and know exactly what's going on, or are trying to debug weird behavior, read on._
+*If you're a casual user/just want to get your app running, you can stop reading now. However, if you want to dig deep and know exactly what's going on, or are trying to debug weird behavior, read on.*
 
 This extension wraps commands in `tilt-restart-wrapper`, which makes use of [`entr`](https://github.com/eradman/entr/)
 to run arbitrary commands whenever a specified file changes. Specifically, we override the container's entrypoint with the following:
@@ -120,4 +120,4 @@ Note: ideally `entr` could accept files-to-watch via flag instead of stdin, but 
 ## For Maintainers: Releasing
 If you have push access to the `tiltdev` on DockerHub, you can release a new version of this extension like so:
 1. run `release.sh` (builds `tilt-restart-wrapper` from source, builds and pushes a Docker image with the new binary and a fresh binary of `entr` also installed from source)
-2. update the image tag in the [Tiltfile](/Tiltfile) with the tag you just pushed (you'll find the image referenced in the Dockerfile contents of the child image--look for "FROM tiltdev/restart-helper")
+2. update the image tag in the [Tiltfile](/restart_process/Tiltfile) with the tag you just pushed (you'll find the image referenced in the Dockerfile contents of the child image--look for "FROM tiltdev/restart-helper")

--- a/restart_process/README.md
+++ b/restart_process/README.md
@@ -113,7 +113,7 @@ When specified as a `command` in Kubernetes or Docker Compose YAML (this is how 
 ```
 Any `args` specified in Kubernetes/Docker Compose are attached to the end of this call, and therefore in this case would apply TO THE `/bin/sh -c` CALL, rather than to the actual command run by `entr`; that is, any `args` specified by the user would be effectively ignored.
 
-In order to make `entr` useable without a shell, this extension uses a simple binary that invokes `entr` and writes to its stdin.
+In order to make `entr` usable without a shell, this extension uses [a simple binary](/restart_process/tilt-restart-wrapper.go) that invokes `entr` and writes to its stdin.
 
 Note: ideally `entr` could accept files-to-watch via flag instead of stdin, but (for a number of good reasons) this feature isn't likely to be added any time soon (see [entr#33](https://github.com/eradman/entr/issues/33)).
 

--- a/restart_process/README.md
+++ b/restart_process/README.md
@@ -118,6 +118,6 @@ In order to make `entr` executable as ARGV rather than as shell, we have wrapped
 Note: ideally `entr` could accept files-to-watch via flag instead of stdin, but (for a number of good reasons) this feature isn't likely to be added any time soon (see [entr#33](https://github.com/eradman/entr/issues/33)).
 
 ## For Maintainers: Releasing
-If you have push access to the `tiltdev` on DockerHub, you can release a new version of this extension like so:
+If you have push access to the `tiltdev` repository on DockerHub, you can release a new version of the binaries used by this extension like so:
 1. run `release.sh` (builds `tilt-restart-wrapper` from source, builds and pushes a Docker image with the new binary and a fresh binary of `entr` also installed from source)
 2. update the image tag in the [Tiltfile](/restart_process/Tiltfile) with the tag you just pushed (you'll find the image referenced in the Dockerfile contents of the child image--look for "FROM tiltdev/restart-helper")

--- a/restart_process/README.md
+++ b/restart_process/README.md
@@ -113,7 +113,7 @@ When specified as a `command` in Kubernetes or Docker Compose YAML (this is how 
 ```
 Any `args` specified in Kubernetes/Docker Compose are attached to the end of this call, and therefore in this case would apply TO THE `/bin/sh -c` CALL, rather than to the actual command run by `entr`; that is, any `args` specified by the user would be effectively ignored.
 
-In order to make `entr` executable as ARGV rather than as shell, we have wrapped it in a binary that can be called directly and takes care of the piping under the hood.
+In order to make `entr` useable without a shell, this extension uses a simple binary that invokes `entr` and writes to its stdin.
 
 Note: ideally `entr` could accept files-to-watch via flag instead of stdin, but (for a number of good reasons) this feature isn't likely to be added any time soon (see [entr#33](https://github.com/eradman/entr/issues/33)).
 

--- a/restart_process/README.md
+++ b/restart_process/README.md
@@ -35,7 +35,7 @@ with a `docker_build_with_restart` call:
 docker_build_with_restart(
     'foo-image',
     './foo',
-    '/go/bin/foo',
+    entrypoint='/go/bin/foo',
     arg1=val1,
     arg2=val2,
     live_update=[x, y, z...]
@@ -43,6 +43,25 @@ docker_build_with_restart(
 ```
 The call above looks just like the initial `docker_build` call except for one added parameter, `entrypoint` (in this example, `/go/bin/foo`). This is the command that you want to run on container start and _re-run_ on Live Update.
 
+### Function Signature
+```python
+def docker_build_with_restart(ref: str, context: str,
+    entrypoint: Union[str, List[str]],
+    live_update: List[LiveUpdateStep],
+    base_suffix: str = '-base',
+    restart_file: str = '/.restart-proc',
+    **kwargs
+):
+    """Args:
+      ref: name for this image (e.g. 'myproj/backend' or 'myregistry/myproj/backend'); as the parameter of the same name in docker_build
+      context: path to use as the Docker build context; as the parameter of the same name in docker_build
+      entrypoint: the command to be (re-)executed when the container starts or when a live_update is run
+      live_update: set of steps for updating a running container; as the parameter of the same name in docker_build
+      base_suffix: suffix for naming the base image, applied as {ref}{base_suffix}
+      restart_file: file that Tilt will update during a live_update to signal the entrypoint to rerun
+      **kwargs: will be passed to the underlying `docker_build` call
+    """
+```
 ## Unsupported Cases
 This extension does NOT support process restarts for:
 - Images run in Docker Compose resources

--- a/restart_process/README.md
+++ b/restart_process/README.md
@@ -43,7 +43,15 @@ docker_build_with_restart(
 ```
 The call above looks just like the initial `docker_build` call except for one added parameter, `entrypoint` (in this example, `/go/bin/foo`). This is the command that you want to run on container start and _re-run_ on Live Update.
 
+## Unsupported Cases
+This extension does NOT support process restarts for:
+- Images run in Docker Compose resources
+- `custom_build`
+
+Run into a bug? Need a use case that we don't yet support? Let us know--[open an issue](https://github.com/windmilleng/tilt-extensions/issues) or [contact us](https://tilt.dev/contact).
+
 ## What's Happening Under the Hood
+*If you're a casual user/just want to get your app running, you can stop reading now. However, if you want to dig deep and know exactly what's going on, or are trying to debug weird behavior, read on._
 
 This extension wraps commands in `tilt-restart-wrapper`, which makes use of [`entr`](https://github.com/eradman/entr/)
 to run arbitrary commands whenever a specified file changes. Specifically, we override the container's entrypoint with the following:
@@ -90,12 +98,7 @@ In order to make `entr` executable as ARGV rather than as shell, we have wrapped
 
 Note: ideally `entr` could accept files-to-watch via flag instead of stdin, but (for a number of good reasons) this feature isn't likely to be added any time soon (see [entr#33](https://github.com/eradman/entr/issues/33)).
 
-## Unsupported Cases
-This extension does NOT support process restarts for:
-- Images run in Docker Compose resources
-- `custom_build`
-
-Run into a bug? Need a use case that we don't yet support? Let us know--[open an issue](https://github.com/windmilleng/tilt-extensions/issues) or [contact us](https://tilt.dev/contact).
-
 ## For Maintainers: Releasing
-TODO(maia) 👀
+If you have push access to the `tiltdev` on DockerHub, you can release a new version of this extension like so:
+1. run `release.sh` (builds `tilt-restart-wrapper` from source, builds and pushes a Docker image with the new binary and a fresh binary of `entr` also installed from source)
+2. update the image tag in the [Tiltfile](/Tiltfile) with the tag you just pushed (you'll find the image referenced in the Dockerfile contents of the child image--look for "FROM tiltdev/restart-helper")

--- a/restart_process/Tiltfile
+++ b/restart_process/Tiltfile
@@ -24,7 +24,7 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
       entrypoint: the command to be (re-)executed when the container starts or when a live_update is run
       live_update: set of steps for updating a running container; as the parameter of the same name in docker_build
       base_suffix: suffix for naming the base image, applied as {ref}{base_suffix}
-      restart_file: file that Tilt will `touch` during a live_update to signal the entrypoint to rerun
+      restart_file: file that Tilt will update during a live_update to signal the entrypoint to rerun
       **kwargs: will be passed to the underlying `docker_build` call
     """
 
@@ -41,14 +41,14 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
     docker_build(base_ref, context, **kwargs)
 
     # declare a new docker build that adds a static binary of tilt-restart-wrapper
-    # (which makes use of entr to watch files and restart processes) to the user's image
+    # (which makes use of `entr` to watch files and restart processes) to the user's image
     df = '''
-    FROM tiltdev/entr:2020-04-27 as entr-img
+    FROM tiltdev/restart-helper:2020-04-27 as restart-helper
 
     FROM {}
     RUN ["touch", "{}"]
-    COPY --from=entr-img /entr /
-    COPY --from=entr-img /tilt-restart-wrapper /
+    COPY --from=restart-helper /tilt-restart-wrapper /
+    COPY --from=restart-helper /entr /
   '''.format(base_ref, restart_file)
 
     # Clean kwargs for building the child image (which builds on user's specified
@@ -59,7 +59,7 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
     cleaned_kwargs = {k: v for k, v in kwargs.items() if k not in KWARGS_BLACKLIST}
 
     # Change the entrypoint to use `tilt-restart-wrapper`.
-    # `tilt-restart-wrapper` makes use of entr (https://github.com/eradman/entr/) to
+    # `tilt-restart-wrapper` makes use of `entr` (https://github.com/eradman/entr/) to
     # re-execute $entrypoint whenever $restart_file changes
     if type(entrypoint) == type(""):
         entrypoint_with_entr = ["/tilt-restart-wrapper", "--watchfile={}".format(restart_file), "sh", "-c", entrypoint]

--- a/restart_process/Tiltfile
+++ b/restart_process/Tiltfile
@@ -70,6 +70,8 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
 
     # last live_update step should always be to modify $restart_file, which
     # triggers the process wrapper to rerun $entrypoint
+    # NB: write `date` instead of just `touch`ing because `entr` doesn't respond
+    # to timestamp changes, only writes (see https://github.com/eradman/entr/issues/32)
     live_update = live_update + [run('date > {}'.format(restart_file))]
 
     docker_build(ref, context, entrypoint=entrypoint_with_entr, dockerfile_contents=df,

--- a/restart_process/release.sh
+++ b/restart_process/release.sh
@@ -3,13 +3,15 @@
 set -e
 
 TIMESTAMP=$(date +'%Y-%m-%d')
-IMAGE_NAME='tiltdev/entr'
+IMAGE_NAME='tiltdev/restart-helper'
 IMAGE_WITH_TAG=$IMAGE_NAME:$TIMESTAMP
 
-# build our binary
+# build binary for tilt-restart-wrapper
 env GOOS=linux GOARCH=amd64 go build tilt-restart-wrapper.go
 
-# build Docker image with our statically compiled entr binary for Linux
+# build Docker image with static binaries of:
+# - tilt-restart-wrapper (compiled above)
+# - entr (dependency of tilt-restart-wrapper)
 docker build . -t $IMAGE_NAME
 docker push $IMAGE_NAME
 

--- a/restart_process/tilt-restart-wrapper.go
+++ b/restart_process/tilt-restart-wrapper.go
@@ -1,3 +1,32 @@
+// `tilt-restart-wrapper` wraps `entr` (http://eradman.com/entrproject/) to easily
+// rerun a user-specified command when a given file changes.
+//
+// This is Tilt's recommended way of restarting a process as part of a live_update:
+// if your container invokes your app via the restart wrapper (e.g. `tilt-restart-wrapper /bin/my-app`),
+// you can trigger re-excecution of you app with a live_update `run` step that makes
+// a trivial change to the file watched by `entr` (e.g. `run('date > /.restart-proc')`)
+//
+// This script exists (i.e. we're wrapping `entr` in a binary instead of invoking
+// it directly) because in its canonical invocation, `entr` requires that the
+// file(s) to watch be piped via stdin, i.e. it is invoked like:
+//     echo "/.restart-proc" | entr -rz /bin/my-app
+//
+// When specified as a `command` in Kubernetes or Docker Compose YAML (this is how
+// Tilt overrides entrypoints), the above would therefore need to be executed as shell:
+//     /bin/sh -c 'echo "/.restart-proc" | entr -rz /bin/my-app'
+
+// Any args specified in Kubernetes or Docker Compose YAML are attached to the end
+// of this call, and therefore in this case apply TO THE `/bin/sh -c` CALL, rather
+// than to the actual command run by `entr`; that is, any `args` specified by the
+// user would be effectively ignored.
+//
+// In order to make `entr` executable as ARGV rather than as shell, we have wrapped it
+// in a binary that can be called directly and takes care of the piping under the hood.
+//
+// Note: ideally `entr` could accept files-to-watch via flag instead of stdin,
+// but (for a number of good reasons) this feature isn't likely to be added any
+// time soon (see https://github.com/eradman/entr/issues/33).
+
 package main
 
 import (


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch maiamcc/restart-container-docs:

ec3e7d824e93bda035079f8805f8f23cb127258d (2020-04-22 13:04:58 -0400)
under the hood explanation

95b04b5bf9fed274426bcd4f64df93e324f230d5 (2020-04-22 12:54:18 -0400)
do footnotes work on github?

c9c4f605eaf0d3d1f23b8fa709e825399f3689e3 (2020-04-22 12:34:41 -0400)
usage docs

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics