### PR TITLE
restart_process: try start.sh instead of entr

### DIFF
--- a/restart_process/Dockerfile
+++ b/restart_process/Dockerfile
@@ -1,8 +1,5 @@
-FROM alpine/git
+FROM alpine
 
-RUN apk update && apk add make
-RUN apk add build-base
-
-# TODO(maia): specify commit instead of just using latest master?
-RUN git clone https://github.com/eradman/entr.git /entr
-RUN cd /entr; ./configure; CFLAGS="-static" make install
+RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh
+RUN wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh
+RUN chmod +x /start.sh && chmod +x /restart.sh

--- a/restart_process/Tiltfile
+++ b/restart_process/Tiltfile
@@ -1,4 +1,3 @@
-RESTART_FILE = '/.restart-proc'
 TYPE_RESTART_CONTAINER_STEP = 'live_update_restart_container_step'
 
 KWARGS_BLACKLIST = [
@@ -13,10 +12,9 @@ KWARGS_BLACKLIST = [
 
 
 def docker_build_with_restart(ref, context, entrypoint, live_update,
-                              base_suffix='-base', restart_file=RESTART_FILE, **kwargs):
+                              base_suffix='-base', shell=False, **kwargs):
     """Wrap a docker_build call and its associated live_update steps so that the last step
     of any live update is to rerun the given entrypoint.
-
 
      Args:
       ref: name for this image (e.g. 'myproj/backend' or 'myregistry/myproj/backend'); as the parameter of the same name in docker_build
@@ -24,7 +22,6 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
       entrypoint: the command to be (re-)executed when the container starts or when a live_update is run
       live_update: set of steps for updating a running container; as the parameter of the same name in docker_build
       base_suffix: suffix for naming the base image, applied as {ref}{base_suffix}
-      restart_file: file that Tilt will `touch` during a live_update to signal the entrypoint to rerun
       **kwargs: will be passed to the underlying `docker_build` call
     """
 
@@ -40,30 +37,36 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
     base_ref = '{}{}'.format(ref, base_suffix)
     docker_build(base_ref, context, **kwargs)
 
-    # declare a new docker build that adds a static binary of entr (previously
-    # compiled by tilt) to the user's image
+    # declare a new docker build that adds Tilt's process wrapper scripts to the user's image
+    # TODO(maia): should the name of the `restart-scripts` image be configurable?
     df = '''
-    FROM tiltdev/entr:2020-16-04 as entr-img
+    FROM tiltdev/restart-scripts:2020-22-04 as scripts-helper
 
     FROM {}
-    RUN ["touch", "{}"]
-    COPY --from=entr-img /entr /
-  '''.format(base_ref, restart_file)
+    COPY --from=scripts-helper /start.sh /
+    COPY --from=scripts-helper /restart.sh /
+  '''.format(base_ref)
 
-    # Clean kwargs for building the child image (which builds on user's specified
-    # image and copies in entr). In practice, this means removing kwargs that were
+    # Clean kwargs for building the child image (which builds on user's specified image
+    # and copies in some scripts). In practice, this means removing kwargs that were
     # relevant to building the user's specified image but are NOT relevant to building
     # the child image / may conflict with args we specifically pass for the child image.
     cleaned_kwargs = {k: v for k, v in kwargs.items() if k not in KWARGS_BLACKLIST}
 
-    # Change the entrypoint to use entr.
-    # entr allows you to run commands when files change: https://github.com/eradman/entr/
-    # this invocation says: whenever $restart_file changes, re-execute $entrypoint
-    entrypoint_with_entr = "echo '{}' | /entr -rz {}".format(restart_file, entrypoint)
+    # Override this image's command to execute the given entrypoint via `start.sh`
+    # (this allows us to later RE-execute the process by running `restart.sh`)
+    if type(entrypoint) == type(""):
+        if shell:
+            entrypoint_with_start_sh = ["/start.sh", "sh", "-c", entrypoint]
+        else:
+            entrypoint_with_start_sh = ["/start.sh", entrypoint]
+    elif type(entrypoint) == type([]):
+        entrypoint_with_start_sh = ["/start.sh"] + entrypoint
+    else:
+        fail("`entrypoint` must be a string or list of strings: got {}".format(type(entrypoint)))
 
-    # last live_update step should always be to modify $restart_file, which
-    # triggers entr to rerun $entrypoint
-    live_update = live_update + [run('date > {}'.format(restart_file))]
+    # last live_update step is to run `restart.sh`, which re-executes the given entrypoint
+    live_update = live_update + [run('/restart.sh')]
 
-    docker_build(ref, context, entrypoint=entrypoint_with_entr, dockerfile_contents=df,
+    docker_build(ref, context, entrypoint=entrypoint_with_start_sh, dockerfile_contents=df,
                  live_update=live_update, **cleaned_kwargs)

--- a/restart_process/Tiltfile
+++ b/restart_process/Tiltfile
@@ -12,7 +12,7 @@ KWARGS_BLACKLIST = [
 
 
 def docker_build_with_restart(ref, context, entrypoint, live_update,
-                              base_suffix='-base', shell=False, **kwargs):
+                              base_suffix='-base', shell_path=None, **kwargs):
     """Wrap a docker_build call and its associated live_update steps so that the last step
     of any live update is to rerun the given entrypoint.
 
@@ -22,9 +22,9 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
       entrypoint: the command to be (re-)executed when the container starts or when a live_update is run
       live_update: set of steps for updating a running container; as the parameter of the same name in docker_build
       base_suffix: suffix for naming the base image, applied as {ref}{base_suffix}
+      shell_path: the path to the container's shell, if not found by shebang "#!usr/bin/env sh"
       **kwargs: will be passed to the underlying `docker_build` call
     """
-
     # first, validate the given live_update steps
     if len(live_update) == 0:
         fail("`docker_build_with_restart` requires at least one live_update step")
@@ -38,7 +38,7 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
     docker_build(base_ref, context, **kwargs)
 
     # declare a new docker build that adds Tilt's process wrapper scripts to the user's image
-    # TODO(maia): should the name of the `restart-scripts` image be configurable?
+    # TODO(maia): should the name of the `scripts-helper` image be configurable?
     df = '''
     FROM tiltdev/restart-scripts:2020-22-04 as scripts-helper
 
@@ -56,17 +56,20 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
     # Override this image's command to execute the given entrypoint via `start.sh`
     # (this allows us to later RE-execute the process by running `restart.sh`)
     if type(entrypoint) == type(""):
-        if shell:
-            entrypoint_with_start_sh = ["/start.sh", "sh", "-c", entrypoint]
-        else:
-            entrypoint_with_start_sh = ["/start.sh", entrypoint]
+        entrypoint_with_start_sh = ["/start.sh", entrypoint]
     elif type(entrypoint) == type([]):
         entrypoint_with_start_sh = ["/start.sh"] + entrypoint
     else:
         fail("`entrypoint` must be a string or list of strings: got {}".format(type(entrypoint)))
 
+    if shell_path:
+        entrypoint_with_start_sh = [shell_path] + entrypoint_with_start_sh
+
     # last live_update step is to run `restart.sh`, which re-executes the given entrypoint
-    live_update = live_update + [run('/restart.sh')]
+    restart_cmd = "/restart.sh"
+    if shell_path:
+        restart_cmd = "{} {}".format(shell_path, restart_cmd)
+    live_update = live_update + [run(restart_cmd)]
 
     docker_build(ref, context, entrypoint=entrypoint_with_start_sh, dockerfile_contents=df,
                  live_update=live_update, **cleaned_kwargs)

--- a/restart_process/release.sh
+++ b/restart_process/release.sh
@@ -3,14 +3,14 @@
 set -e
 
 TIMESTAMP=$(date +'%Y-%d-%m')
-IMAGE_NAME='tiltdev/entr'
+IMAGE_NAME='tiltdev/restart-scripts'
 IMAGE_WITH_TAG=$IMAGE_NAME:$TIMESTAMP
 
-# build Docker image with our statically compiled entr binary for Linux
+# build Docker image with our start and restart scripts from latest master
 docker build . -t $IMAGE_NAME
 docker push $IMAGE_NAME
 
-docker tag tiltdev/entr $IMAGE_WITH_TAG
+docker tag $IMAGE_NAME $IMAGE_WITH_TAG
 docker push $IMAGE_WITH_TAG
 
 


### PR DESCRIPTION
since `entr` must be executed as shell for piping, it means we can't
pass it as a list of args, which means that a user's k8s yaml args
will never propogate up to the command they're running.

I tried reimplementing this extension using re/start.sh to see
how hard it would be. It was pretty easy, though there remains a
similar stumbling block: how to let a user specify an entrypoint
in shell, if they want, or as argv (and therefore compatible with
`args` in k8s yaml). it's not perfect, but the `shell` param is
a stopgap.

this implementation solves the problem of the previous implementation:
it's now possible to pass an `entrypoint` such that, if `args` are present
in the yaml, they actually apply to the correct executable

this works fine with servantes and example-go, and is throwing weird errors
in cluster-api, I'll dig in tomorrow