### PR TITLE
restart_process: use pre-compiled bin of entr that doesn't need to be run as shell

### DIFF
--- a/restart_process/.gitignore
+++ b/restart_process/.gitignore
@@ -1,0 +1,1 @@
+tilt-restart-wrapper

--- a/restart_process/Dockerfile
+++ b/restart_process/Dockerfile
@@ -6,3 +6,5 @@ RUN apk add build-base
 # TODO(maia): specify commit instead of just using latest master?
 RUN git clone https://github.com/eradman/entr.git /entr
 RUN cd /entr; ./configure; CFLAGS="-static" make install
+
+ADD tilt-restart-wrapper /

--- a/restart_process/Tiltfile
+++ b/restart_process/Tiltfile
@@ -40,29 +40,36 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
     base_ref = '{}{}'.format(ref, base_suffix)
     docker_build(base_ref, context, **kwargs)
 
-    # declare a new docker build that adds a static binary of entr (previously
-    # compiled by tilt) to the user's image
+    # declare a new docker build that adds a static binary of tilt-restart-wrapper
+    # (which makes use of entr to watch files and restart processes) to the user's image
     df = '''
-    FROM tiltdev/entr:2020-16-04 as entr-img
+    FROM tiltdev/entr:2020-04-24 as entr-img
 
     FROM {}
     RUN ["touch", "{}"]
     COPY --from=entr-img /entr /
+    COPY --from=entr-img /tilt-restart-wrapper /
   '''.format(base_ref, restart_file)
 
     # Clean kwargs for building the child image (which builds on user's specified
-    # image and copies in entr). In practice, this means removing kwargs that were
-    # relevant to building the user's specified image but are NOT relevant to building
-    # the child image / may conflict with args we specifically pass for the child image.
+    # image and copies in Tilt's restart wrapper). In practice, this means removing
+    # kwargs that were relevant to building the user's specified image but are NOT
+    # relevant to building the child image / may conflict with args we specifically
+    # pass for the child image.
     cleaned_kwargs = {k: v for k, v in kwargs.items() if k not in KWARGS_BLACKLIST}
 
-    # Change the entrypoint to use entr.
-    # entr allows you to run commands when files change: https://github.com/eradman/entr/
-    # this invocation says: whenever $restart_file changes, re-execute $entrypoint
-    entrypoint_with_entr = "echo '{}' | /entr -rz {}".format(restart_file, entrypoint)
+    # Change the entrypoint to use `tilt-restart-wrapper`.
+    # `tilt-restart-wrapper` makes use of entr (https://github.com/eradman/entr/) to
+    # re-execute $entrypoint whenever $restart_file changes
+    if type(entrypoint) == type(""):
+        entrypoint_with_entr = ["/tilt-restart-wrapper", "--watchfile={}".format(restart_file), "sh", "-c", entrypoint]
+    elif type(entrypoint) == type([]):
+        entrypoint_with_entr = ["/tilt-restart-wrapper", "--watchfile={}".format(restart_file)] + entrypoint
+    else:
+        fail("`entrypoint` must be a string or list of strings: got {}".format(type(entrypoint)))
 
     # last live_update step should always be to modify $restart_file, which
-    # triggers entr to rerun $entrypoint
+    # triggers the process wrapper to rerun $entrypoint
     live_update = live_update + [run('date > {}'.format(restart_file))]
 
     docker_build(ref, context, entrypoint=entrypoint_with_entr, dockerfile_contents=df,

--- a/restart_process/Tiltfile
+++ b/restart_process/Tiltfile
@@ -43,7 +43,7 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
     # declare a new docker build that adds a static binary of tilt-restart-wrapper
     # (which makes use of entr to watch files and restart processes) to the user's image
     df = '''
-    FROM tiltdev/entr:2020-04-24 as entr-img
+    FROM tiltdev/entr:2020-04-27 as entr-img
 
     FROM {}
     RUN ["touch", "{}"]

--- a/restart_process/main.go
+++ b/restart_process/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+var defaultWatchFile = "/.restart-proc"
+var watchFile = flag.String("watchfile", "", "File that entr will watch for changes; changes to this file trigger entr to rerun the command(s) passed")
+
+func main() {
+	flag.Parse()
+
+	args := os.Args[1:]
+	if *watchFile == "" {
+		*watchFile = defaultWatchFile
+	} else {
+		// user passed this arg, make sure we don't pass it along to entr
+		args = os.Args[2:]
+	}
+	fmt.Println("Hello, world.")
+	fmt.Println("args:", args)
+	cmd := exec.Command("/entr", "-rz")
+	cmd.Stdin = strings.NewReader(fmt.Sprintf("%s\n", *watchFile))
+	cmd.Args = append(cmd.Args, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			// The program has exited with an exit code != 0
+			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+				os.Exit(status.ExitStatus())
+			}
+		} else {
+			log.Fatalf("error running command: %v", err)
+		}
+	}
+}

--- a/restart_process/release.sh
+++ b/restart_process/release.sh
@@ -7,7 +7,7 @@ IMAGE_NAME='tiltdev/entr'
 IMAGE_WITH_TAG=$IMAGE_NAME:$TIMESTAMP
 
 # build our binary
-env GOOS=linux GOARCH=amd64 go build -o tilt-restart-wrapper main.go
+env GOOS=linux GOARCH=amd64 go build tilt-restart-wrapper.go
 
 # build Docker image with our statically compiled entr binary for Linux
 docker build . -t $IMAGE_NAME

--- a/restart_process/release.sh
+++ b/restart_process/release.sh
@@ -16,5 +16,7 @@ docker push $IMAGE_NAME
 docker tag tiltdev/entr $IMAGE_WITH_TAG
 docker push $IMAGE_WITH_TAG
 
+echo "Successfully built and pushed $IMAGE_WITH_TAG"
+
 
 

--- a/restart_process/release.sh
+++ b/restart_process/release.sh
@@ -2,9 +2,12 @@
 
 set -e
 
-TIMESTAMP=$(date +'%Y-%d-%m')
+TIMESTAMP=$(date +'%Y-%m-%d')
 IMAGE_NAME='tiltdev/entr'
 IMAGE_WITH_TAG=$IMAGE_NAME:$TIMESTAMP
+
+# build our binary
+env GOOS=linux GOARCH=amd64 go build -o tilt-restart-wrapper main.go
 
 # build Docker image with our statically compiled entr binary for Linux
 docker build . -t $IMAGE_NAME

--- a/restart_process/tilt-restart-wrapper.go
+++ b/restart_process/tilt-restart-wrapper.go
@@ -10,8 +10,7 @@ import (
 	"syscall"
 )
 
-var defaultWatchFile = "/.restart-proc"
-var watchFile = flag.String("watch_file", "", "File that entr will watch for changes; changes to this file trigger entr to rerun the command(s) passed")
+var watchFile = flag.String("watch_file", "/.restart-proc", "File that entr will watch for changes; changes to this file trigger `entr` to rerun the command(s) passed")
 var entrPath = flag.String("entr_path", "/entr", "Path to `entr` executable")
 
 func main() {


### PR DESCRIPTION
problem: using `entr` as a solution for restarting processes meant we had to run `echo filename | entr...` ie had to run wrapped in `sh -c` which meant that args specified in k8s yaml would never take effect (because they were applied to the `sh` call rather than the user's executable)

solution: compilee a wrapper for `entr` so we can invoke it without piping