### PR TITLE
An extension to use pack and buildpacks to build container images

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ All extensions have been vetted and approved by the Tilt team.
 - [`hello_world`](/hello_world): Print "Hello world!". Used in [Extensions](https://docs.tilt.dev/extensions.html).
 - [`jest_test_runner`](/jest_test_runner): Jest JavaScript test runner. Example from [Contribute an Extension](https://docs.tilt.dev/contribute_extension.html).
 - [`min_tilt_version`](/min_tilt_version): Require a minimum Tilt version to run this Tiltfile.
+- [`pack`](/pack): Build container images using [pack](https://buildpacks.io/docs/install-pack/) and [buildpacks](https://buildpacks.io/).
 - [`print_tiltfile_dir`](/print_tiltfile_dir): Print all files in the Tiltfile directory. If recursive is set to True, also prints files in all recursive subdirectories.
 - [`procfile`](/procfile): Create Tilt resources from a foreman Procfile.
 

--- a/pack/README.md
+++ b/pack/README.md
@@ -1,0 +1,40 @@
+# Use Pack to build container images
+
+Build container images using [pack](https://buildpacks.io/docs/install-pack/) and [buildpacks](https://buildpacks.io/).
+
+## Usage
+
+This extension adds the `pack` function, which is used the same way as `docker_build` to allow Tilt
+to automatically build a container image with a known name. For instance the following example shows
+building an image using the default builder and having that image automatically deployed to Kubernetes.
+
+```python
+load('ext://pack', 'pack')
+
+pack('example-image')
+k8s_yaml('kubernetes.yaml')
+k8s_resource('example-deployment', port_forwards=8000)
+```
+
+The `pack` function can take a few arguments:
+
+* `name`: name of the image to be built
+* `path`: path to application directory, defaults to the current working directory
+* `builder`: builder image, defaults to gcr.io/paketo-buildpacks/builder:base
+
+The function also supports all of the properties of [`custom_build`](https://docs.tilt.dev/api.html#api.custom_build) so
+you can ignore files, override the entrypoint or set live updates as usual.
+
+For instance, if you want to use the tiny builder instead of the default [Paketo](https://paketo.io/) one,
+you would do the following:
+
+```python
+pack(
+  'example-image',
+  builder='gcr.io/paketo-buildpacks/builder:tiny'
+)
+```
+
+## Requirements
+
+* The `pack` binary must be on your path

--- a/pack/Tiltfile
+++ b/pack/Tiltfile
@@ -1,0 +1,19 @@
+# -*- mode: Python -*-
+
+def pack(name, path=".", builder="gcr.io/paketo-buildpacks/builder:base", **kwargs):
+    """
+    Build a container image using pack and buildpacks.
+
+    Args:
+      name: name of the image to build
+      path: path to application directory, defaults to current working directory
+      builder: builder image, defaults to gcr.io/paketo-buildpacks/builder:base
+      **kwargs: will be passed to the underlying `custom_build` call
+
+    """
+    custom_build(
+        name,
+        "pack build $EXPECTED_REF -p %s --builder %s" % (path, builder),
+        [path],
+        **kwargs
+    )


### PR DESCRIPTION
First pass at an extension for using pack. There are a few arguments on `pack` that would be useful to expose here as well, but this covers the main use case I think.

@victorwuky as mentioned in the docs.