### PR TITLE
restart_process: ugh get the script name right

### DIFF
--- a/restart_process/README.md
+++ b/restart_process/README.md
@@ -72,7 +72,7 @@ This extension wraps commands in `tilt-restart-wrapper`, which makes use of [`en
 to run arbitrary commands whenever a specified file changes. Specifically, we override the container's entrypoint with the following:
 
 ```
-/tilt-restart-wrapper --watchfile='/.restart-proc' <entrypoint>
+/tilt-restart-wrapper --watch_file='/.restart-proc' <entrypoint>
 ```
 
 This invocation says:

--- a/restart_process/Tiltfile
+++ b/restart_process/Tiltfile
@@ -62,9 +62,9 @@ def docker_build_with_restart(ref, context, entrypoint, live_update,
     # `tilt-restart-wrapper` makes use of `entr` (https://github.com/eradman/entr/) to
     # re-execute $entrypoint whenever $restart_file changes
     if type(entrypoint) == type(""):
-        entrypoint_with_entr = ["/tilt-restart-wrapper", "--watchfile={}".format(restart_file), "sh", "-c", entrypoint]
+        entrypoint_with_entr = ["/tilt-restart-wrapper", "--watch_file={}".format(restart_file), "sh", "-c", entrypoint]
     elif type(entrypoint) == type([]):
-        entrypoint_with_entr = ["/tilt-restart-wrapper", "--watchfile={}".format(restart_file)] + entrypoint
+        entrypoint_with_entr = ["/tilt-restart-wrapper", "--watch_file={}".format(restart_file)] + entrypoint
     else:
         fail("`entrypoint` must be a string or list of strings: got {}".format(type(entrypoint)))
 


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch maiamcc/stupid-error:

4dd6719f0a7073eaab47103786830db6d3b3635e (2020-04-28 17:40:57 -0400)
restart_process: ugh get the script name right

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics